### PR TITLE
docs: fix CONTRIBUTING.md architecture link markdown

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ This document details how to get started contributing to the project.  This incl
 Install git hooks that do basic pre-commit checks.
 
 **Tip**:
-Read through our (architecture)[ARCHITECTURE.md] file for how we structure this project (Or have AI do it!)
+Read through our [architecture](ARCHITECTURE.md) file for how we structure this project (Or have AI do it!)
 
 ```sh
 make setup-githooks


### PR DESCRIPTION
<!-- PR Title: docs: fix CONTRIBUTING.md architecture link markdown -->

# Changes

- :bug: Fix inverted markdown link syntax in CONTRIBUTING.md so the architecture tip links to `ARCHITECTURE.md` instead of rendering as plain text.

/kind documentation

Relates to Hamr Functions#56 (#395 external-dev e2e vehicle)

**Release Note**

```release-note
NONE
```

**Docs**

```docs
N/A — CONTRIBUTING.md only
```

---

**Provisional fork PR** (Hamr #395 external-dev loop). CI/bot surface only — **not** the merge path. Upstream PR opens only after operator-spoken go.