### PR TITLE
test/build: fail-loud make + silence git for jj workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ __pycache__
 /templates/python/cloudevents/.venv
 /templates/python/http/.venv
 
+# Java
+/templates/**/.mvn/wrapper/maven-wrapper.jar
+
 # AI
 AGENTS.override.md
 .claude/*.local.*

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,13 @@
 #
 # ##
 
-# Use bash with pipefail so targets whose recipes pipe through tee/python
-# (e.g. test-full-logged) surface non-zero exits from the upstream command
-# instead of being masked by tee's success.
+# Use bash with errexit + pipefail so recipes halt on first failure and
+# surface non-zero exits from any stage of a pipeline (e.g. tee/python in
+# test-full-logged, or hack/vcs.sh ls-sources upstream of a checker). Errexit
+# is suppressed inside && / || / loops, so existing `cmd && ... || true`
+# patterns in check-* targets continue to work as intended.
 SHELL       := bash
-.SHELLFLAGS := -o pipefail -c
+.SHELLFLAGS := -eo pipefail -c
 
 # Binaries
 BIN               := func
@@ -31,10 +33,10 @@ BIN_GOIMPORTS     ?= "$(PWD)/bin/goimports"
 # If the current commit does not have a semver tag, 'tip' is used, unless there
 # is a TAG environment variable. Precedence is git tag, environment variable, 'tip'
 HASH         := $(shell git rev-parse --short HEAD 2>/dev/null)
-VTAG         := $(shell git tag --points-at HEAD | head -1)
+VTAG         := $(shell git tag --points-at HEAD 2>/dev/null | head -1)
 VTAG         := $(shell [ -z $(VTAG) ] && echo $(ETAG) || echo $(VTAG))
-VERS         ?= $(shell git describe --tags --match 'v*')
-KVER         ?= $(shell git describe --tags --match 'knative-*')
+VERS         ?= $(shell git describe --tags --match 'v*' 2>/dev/null)
+KVER         ?= $(shell git describe --tags --match 'knative-*' 2>/dev/null)
 
 LDFLAGS      := -X knative.dev/func/pkg/version.Vers=$(VERS) -X knative.dev/func/pkg/version.Kver=$(KVER) -X knative.dev/func/pkg/version.Hash=$(HASH)
 

--- a/hack/common-func.sh
+++ b/hack/common-func.sh
@@ -1,0 +1,106 @@
+# Common utilities for scripts that use `func cluster create` managed paths.
+#
+# This is the successor to common.sh for scripts that work with the new
+# func-managed cluster infrastructure (binaries at $XDG_CONFIG_HOME/func/bin,
+# kubeconfig at $XDG_CONFIG_HOME/func/clusters/{name}.local/kubeconfig.yaml).
+#
+# Scripts that still use the old hack/bin/ paths should continue to source
+# common.sh instead.
+
+init() {
+  set_func_paths
+  find_executables
+  define_colors
+}
+
+# set_func_paths configures FUNC_CONFIG_DIR, BIN_DIR, and KUBECONFIG
+# using the same path logic as pkg/cluster/config.go.
+set_func_paths() {
+  local cluster_name="${FUNC_CLUSTER_NAME:-func}"
+
+  if [[ -n "${XDG_CONFIG_HOME:-}" ]]; then
+    FUNC_CONFIG_DIR="${XDG_CONFIG_HOME}/func"
+  else
+    FUNC_CONFIG_DIR="${HOME}/.config/func"
+  fi
+
+  BIN_DIR="${FUNC_CONFIG_DIR}/bin"
+  export KUBECONFIG="${FUNC_CONFIG_DIR}/clusters/${cluster_name}.local/kubeconfig.yaml"
+
+  # Detect architecture
+  if [[ -z "${ARCH:-}" ]]; then
+    local machine_arch
+    machine_arch=$(uname -m)
+    case $machine_arch in
+      x86_64) export ARCH="amd64" ;;
+      aarch64|arm64) export ARCH="arm64" ;;
+      *) export ARCH="amd64" ;;
+    esac
+  else
+    export ARCH="$ARCH"
+  fi
+
+  export CONTAINER_ENGINE=${CONTAINER_ENGINE:-docker}
+  export TERM="${TERM:-dumb}"
+
+  echo "FUNC_CONFIG_DIR=${FUNC_CONFIG_DIR}"
+  echo "BIN_DIR=${BIN_DIR}"
+  echo "KUBECONFIG=${KUBECONFIG}"
+  echo "CONTAINER_ENGINE=${CONTAINER_ENGINE}"
+}
+
+# find_executables locates kubectl (the only host-side tool the test scripts
+# shell out to; all other tools are invoked through the `func` binary).
+# Fallback order: FUNC_TEST_KUBECTL > $FUNC_CONFIG_DIR/bin/kubectl > PATH.
+find_executables() {
+  KUBECTL=$(find_executable "kubectl" || true)
+}
+
+find_executable() {
+  local name="$1"
+  local path=""
+
+  # 1. Environment variable override
+  local env
+  env=$(echo "FUNC_TEST_$name" | awk '{print toupper($0)}')
+  path="${!env:-}"
+  if [[ -x "$path" ]]; then
+    echo "$path"; return 0
+  fi
+
+  # 2. func-managed bin directory
+  path="${BIN_DIR}/${name}"
+  if [[ -x "$path" ]]; then
+    echo "$path"; return 0
+  fi
+
+  # 3. System PATH
+  path=$(command -v "$name")
+  if [[ -x "$path" ]]; then
+    echo "$path"; return 0
+  fi
+
+  echo "Warning: ${name} not found." >&2
+  return 1
+}
+
+define_colors() {
+  local TERM="$TERM"
+  if [[ -z "$TERM" || "$TERM" == "dumb" ]]; then
+    TERM="xterm"
+  fi
+  # shellcheck disable=SC2155
+  red=$(tput bold)$(tput setaf 1)
+  # shellcheck disable=SC2155
+  green=$(tput bold)$(tput setaf 2)
+  # shellcheck disable=SC2155
+  blue=$(tput bold)$(tput setaf 4)
+  # shellcheck disable=SC2155
+  grey=$(tput bold)$(tput setaf 8)
+  # shellcheck disable=SC2155
+  yellow=$(tput bold)$(tput setaf 11)
+  # shellcheck disable=SC2155
+  reset=$(tput sgr0)
+}
+
+init "$@"

--- a/hack/test-full.sh
+++ b/hack/test-full.sh
@@ -14,14 +14,14 @@
 # replicate what is run in GitHub CI, but locally and without
 # parallelization.
 #
-# This script presumes a local testing environment set up using the
-# helper scripts in ./hack and performs some precondition checks to ensure
-# resources are available for the features enabled (nonexhaustive).
-#     hack/binaries.sh   - Installs necessary binaries in ./hack/bin
-#     hack/registry.sh   - Starts and configures a local container registry
-#     hack/cluster.sh    - Start test cluster with Knative Serving/Eventing
-#     hack/gitlab.sh     - Installs GitLab in-cluster
-#     hack/git-server.sh - Starts a git server in-cluster
+# This script presumes a local testing environment set up using:
+#     func cluster create        - Creates test cluster with Knative, registry, etc.
+#     func cluster create --dapr - Also installs Dapr (needed for some integration tests)
+#     hack/gitlab.sh             - Installs GitLab in-cluster
+#     hack/git-server.sh         - Starts a git server in-cluster
+#
+# Binaries (kubectl, kind, etc.) and kubeconfig are managed by
+# `func cluster create` at $XDG_CONFIG_HOME/func/ (typically ~/.config/func/).
 #
 # Also note that when run with all default options, the "Matrix"
 # test will run, requiring that all supported language toolchains are
@@ -36,7 +36,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-source "$(cd "$(dirname "$0")" && pwd)/common.sh"
+source "$(cd "$(dirname "$0")" && pwd)/common-func.sh"
 
 # Enable Optional Tests
 # ---------------------
@@ -79,22 +79,24 @@ setup() {
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-    # Set PATH and KUBECONFIG
-    export PATH="${PROJECT_ROOT}/hack/bin:${PATH}"
-    export KUBECONFIG="${KUBECONFIG:-${PROJECT_ROOT}/hack/bin/kubeconfig.yaml}"
+    # KUBECONFIG is set by common-func.sh using func-managed paths:
+    #   $XDG_CONFIG_HOME/func/clusters/{name}.local/kubeconfig.yaml
+
+    # Point the E2E and integration tests at the managed kubeconfig and tools.
+    # These tests deliberately ignore KUBECONFIG and installed bins, using
+    # their own, with a fallback to the old hack/bin/.
+    export FUNC_E2E_TOOLS="${FUNC_E2E_TOOLS:-${BIN_DIR}}"
+    export FUNC_E2E_KUBECONFIG="${FUNC_E2E_KUBECONFIG:-${KUBECONFIG}}"
+    export FUNC_INT_KUBECONFIG="${FUNC_INT_KUBECONFIG:-${KUBECONFIG}}"
 
     # GitLab test configuration
-    # This is the default set by ./hack/gitlab.sh, and is overridden in CI, and
-    # a warning is issued that users should not only use ./hack/gitlab.sh for
-    # configuring test cluster available locally, such as that created by
-    # hack/cluster.sh
     export FUNC_TEST_GITLAB_PASS="${FUNC_TEST_GITLAB_PASS:-test-password-123}"
 
     # Generate a timestamp for use setting things which require uniqueness
     TIMESTAMP=$(date +%Y%m%d%H%M%S 2>/dev/null || date +%s 2>/dev/null || echo "$(date)")
 
     # Initialize coverage file
-    echo "mode: atomic" > coverage.txt
+    echo "mode: atomic" >coverage.txt
 }
 
 # -------------
@@ -104,45 +106,32 @@ preconditions() {
     echo ""
     echo "${blue}Preconditions${reset}"
 
-    # Check if binaries are installed
-    if [ ! -d "${PROJECT_ROOT}/hack/bin" ]; then
-        echo "ERROR: hack/bin directory not found!"
-        echo "Please run ./hack/binaries.sh first to install required tools."
-        exit 1
-    fi
-    MISSING_BINS=""
-    for bin in kubectl kind jq stern dapr helm kn act; do
-        # Check with and without .exe for Windows compatibility
-        if [ ! -f "${PROJECT_ROOT}/hack/bin/${bin}" ] && [ ! -f "${PROJECT_ROOT}/hack/bin/${bin}.exe" ]; then
-            MISSING_BINS="${MISSING_BINS} ${bin}"
-        fi
-    done
-
-    if [ -n "${MISSING_BINS}" ]; then
-        echo "ERROR: Required binaries not found:${MISSING_BINS}"
-        echo "Please run ./hack/binaries.sh to install required tools."
+    # Check that kubectl is available (installed by func cluster create)
+    if [[ -z "$KUBECTL" ]]; then
+        echo "ERROR: kubectl not found"
+        echo "Please run 'func cluster create' to set up a test cluster."
         exit 1
     fi
 
     # Check if cluster is allocated
     if [ ! -f "${KUBECONFIG}" ]; then
         echo "ERROR: KUBECONFIG not found at ${KUBECONFIG}"
-        echo "Please run ./hack/cluster.sh to set up a test cluster."
+        echo "Please run 'func cluster create' to set up a test cluster."
         exit 1
     fi
 
     # Verify cluster connectivity
-    if ! kubectl cluster-info &>/dev/null; then
+    if ! $KUBECTL cluster-info &>/dev/null; then
         echo "ERROR: Cannot connect to Kubernetes cluster"
         echo "KUBECONFIG: ${KUBECONFIG}"
         echo "Please ensure your cluster is running and KUBECONFIG is valid."
-        echo "You may need to run ./hack/cluster.sh"
+        echo "You may need to run 'func cluster create'"
         exit 1
     fi
 
     # Check if GitLab is installed (if GitLab tests are enabled)
     if [ "${FUNC_INT_GITLAB_ENABLED}" = "1" ]; then
-        if ! kubectl get namespace gitlab &>/dev/null; then
+        if ! $KUBECTL get namespace gitlab &>/dev/null; then
             echo "ERROR: GitLab namespace not found"
             echo "Please run ./hack/gitlab.sh to install GitLab"
             exit 1


### PR DESCRIPTION
## Summary

Make recipes fail loud and stop `git` spam in jj-only workspaces; point
`test-full` at func-managed cluster paths.

Complements knative/func#3873 (`hack/vcs.sh` / `LS_SOURCES`).

## Changes

- **Makefile**: `.SHELLFLAGS -eo pipefail`; silence top-level `$(shell git …)` with `2>/dev/null`
- **.gitignore**: Java maven-wrapper.jar under templates
- **hack/common-func.sh**: new helpers for `$XDG_CONFIG_HOME/func/` bins + kubeconfig
- **hack/test-full.sh**: source common-func; `FUNC_E2E_TOOLS` / kubeconfig exports; preconditions via `func cluster create`

## Test plan

- [x] Rebased on current main cleanly
- [x] `make` in jj-only workspace does not print `fatal: not a git repository`
- [x] `bash -n` on common-func.sh / test-full.sh
- [ ] CI

Functions#59