### PR TITLE
chore: ignore CLAUDE.local.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ __pycache__
 
 # AI
 AGENTS.override.md
+CLAUDE.local.md
 .claude/*.local.*
 .claude/pr/*
 .claude/plans/*


### PR DESCRIPTION
## Summary

Add `CLAUDE.local.md` to the repo `.gitignore` under the existing `# AI` block,
peer to `AGENTS.override.md`.

Root-level local Claude overrides are not covered by `.claude/*.local.*`
(prefix-scoped to `.claude/`). Unanchored pattern matches the
`AGENTS.override.md` peer style so any-depth `CLAUDE.local.md` stays out of
commits.

## Changes

- :broom: `.gitignore`: ignore `CLAUDE.local.md` under `# AI`

/kind cleanup

## Test plan

- [x] Diff is the single intended line vs main
- [x] No other files from unrelated local stacks
- [ ] Fork CI

Functions#60